### PR TITLE
WPC-254: Fix of "client passes supplied Accept-Encoding headers as its own" issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.0.3] - 2022-12-05
+
+Avoid sending headers from the device that has to be looked up as client request http header. 
+They are just sent as request json payload. This avoid issues with Brotly or other framwork/libraries
+
 ## [2.0.2] - 2020-07-06
 - Update web example to use Laminas\Diactoros. Now requires PHP >= 7.1
 - [README] Update installation step with composer

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "scientiamobile/wm-client",
   "description": "WURFL Microservice PHP API",
   "license": "proprietary",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "authors": [
     {
       "name": "Luca Corbo"

--- a/src/WMClient.php
+++ b/src/WMClient.php
@@ -121,7 +121,7 @@ class WMClient
      */
     public function getApiVersion()
     {
-        return '2.0.0';
+        return '2.0.3';
     }
 
     /**
@@ -241,7 +241,7 @@ class WMClient
         $jsonRequest->lookupHeaders($headers);
         $jsonRequest->requestedCaps($this->requestedStaticCapabilities);
         $jsonRequest->requestedVCaps($this->requestedVirtualCapabilities);
-        $response = $this->client->post($endpoint, $this->makeHeaders($headers), $jsonRequest);
+        $response = $this->client->post($endpoint, $this->makeHeaders(), $jsonRequest);
 
         $deviceData = new JsonDeviceData($response);
 
@@ -272,7 +272,7 @@ class WMClient
         $jsonRequest->lookupHeaders($headers);
         $jsonRequest->requestedCaps($this->requestedStaticCapabilities);
         $jsonRequest->requestedVCaps($this->requestedVirtualCapabilities);
-        $response = $this->client->post($endpoint, $this->makeHeaders($headers), $jsonRequest);
+        $response = $this->client->post($endpoint, $this->makeHeaders(), $jsonRequest);
 
         $deviceData = new JsonDeviceData($response);
 

--- a/tests/Integration/WMClientTest.php
+++ b/tests/Integration/WMClientTest.php
@@ -168,6 +168,35 @@ class WMClientTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('touchscreen', $deviceData->capabilities('pointing_method'));
     }
 
+    public function testLookupRequest()
+    {
+        $client = $this->makeTestClient();
+
+        $url = "http://vimeo.com/api/v2/brad/info.json";
+        $headers = [
+            "Content-Type" => "application/json",
+            "Accept-Encoding" => "gzip, deflate",
+            "User-Agent" => "Mozilla/5.0 (Nintendo Switch; WebApplet) AppleWebKit/601.6 (KHTML, like Gecko) NF/4.0.0.5.9 NintendoBrowser/5.1.0.13341",
+        ];
+        $request = new Request("GET", $url, $headers);
+        $deviceData = $client->lookupRequest($request);
+        $this->assertSame('Nintendo', $deviceData->capabilities('brand_name'));
+        $this->assertSame('Switch', $deviceData->capabilities('model_name'));
+        $this->assertSame('touchscreen', $deviceData->capabilities('pointing_method'));
+        $this->assertSame('720', $deviceData->capabilities('resolution_height'));
+        $this->assertSame('1280', $deviceData->capabilities('resolution_width'));
+
+
+        $mtime = $deviceData->mtime();
+
+        //Test client is not using cache
+        sleep(1);
+        $deviceData = $client->lookupRequest($request);
+        $this->assertNotSame($mtime, $deviceData->mtime());
+
+
+    }
+
 
     public function testLookupRequestWithSpecifiedCaps()
     {
@@ -218,6 +247,24 @@ class WMClientTest extends \PHPUnit_Framework_TestCase
         sleep(1);
         $deviceData = $client->lookupRequest($request);
         $this->assertSame($mtime, $deviceData->mtime());
+        $this->assertSame('Nintendo', $deviceData->capabilities('brand_name'));
+        $this->assertSame('Switch', $deviceData->capabilities('model_name'));
+        $this->assertSame('touchscreen', $deviceData->capabilities('pointing_method'));
+    }
+
+    public function testLookupRequestWithMixedCaseHeaders()
+    {
+        $client = $this->makeTestClient();
+        $client->setRequestedStaticCapabilities(["brand_name", "is_wireless_device", "pointing_method", "model_name"]);
+
+        $url = "http://vimeo.com/api/v2/brad/info.json";
+        $headers = [
+            "ConteNT-TyPe" => "application/json",
+            "Accept-EncODing" => "gzip, deflate",
+            "User-AGenT" => "Mozilla/5.0 (Nintendo Switch; WebApplet) AppleWebKit/601.6 (KHTML, like Gecko) NF/4.0.0.5.9 NintendoBrowser/5.1.0.13341",
+        ];
+        $request = new Request("GET", $url, $headers);
+        $deviceData = $client->lookupRequest($request);
         $this->assertSame('Nintendo', $deviceData->capabilities('brand_name'));
         $this->assertSame('Switch', $deviceData->capabilities('model_name'));
         $this->assertSame('touchscreen', $deviceData->capabilities('pointing_method'));

--- a/tests/WMClientTest.php
+++ b/tests/WMClientTest.php
@@ -48,63 +48,6 @@ class WMClientTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals(['brand_name'], 'requestedStaticCapabilities', $client);
     }
 
-    public function testLookupRequest()
-    {
-        $ua = "Mozilla/5.0 (Nintendo Switch; WebApplet) AppleWebKit/601.6 (KHTML, like Gecko) NF/4.0.0.5.9 NintendoBrowser/5.1.0.13341";
-        $default_ua = 'php-wmclient-api ' . 'WM-test';
-        $expected_request_ua = $default_ua . ' ' . $ua;
-        $httpClient = $this->prophesize('\ScientiaMobile\WMClient\HttpClient\HttpClientInterface');
-        $response = ResponseMocker::wmValidServerInfoResponse();
-        $httpClient->getDefaultUserAgent()->willReturn('WM-test');
-        $httpClient->get("/v2/getinfo/json", [
-            "User-Agent" => $default_ua,
-        ])->willReturn($response);
-        $httpClient->post(
-            "/v2/lookuprequest/json",
-            [
-                "User-Agent" => $expected_request_ua,
-                "Accept-Encoding" => "gzip, deflate"
-            ],
-            Argument::any()
-        )
-            ->willReturn(ResponseMocker::wmValidDeviceResponse());
-
-        $client = new WMClient($httpClient->reveal());
-        $url = "http://vimeo.com/api/v2/brad/info.json";
-        $headers = [
-            "Content-Type" => "application/json",
-            "Accept-Encoding" => "gzip, deflate",
-            "User-Agent" => $ua,
-        ];
-        $request = new Request("GET", $url, $headers);
-
-        $client->lookupRequest($request);
-    }
-
-    public function testLookupUserAgent()
-    {
-        $ua = 'Mozilla';
-        $default_ua = 'php-wmclient-api ' . 'WM-test';
-        $expected_request_ua = $default_ua . ' ' . $ua;
-        $httpClient = $this->prophesize('\ScientiaMobile\WMClient\HttpClient\HttpClientInterface');
-        $response = ResponseMocker::wmValidServerInfoResponse();
-        $httpClient->getDefaultUserAgent()->willReturn('WM-test');
-        $httpClient->get("/v2/getinfo/json", [
-            "User-Agent" => $default_ua,
-        ])->willReturn($response);
-        $httpClient->post(
-            "/v2/lookupuseragent/json",
-            ["User-Agent" => $expected_request_ua],
-            Argument::any()
-        )
-            ->willReturn(ResponseMocker::wmValidDeviceResponse());
-
-        $client = new WMClient($httpClient->reveal());
-
-        $device = $client->lookupUserAgent('Mozilla');
-        $this->assertSame('samsung_sm_g950f_int_ver1', $device->capabilities('wurfl_id'));
-    }
-
     public function testLookupDeviceID()
     {
         $httpClient = $this->mockHttpClient();
@@ -142,39 +85,4 @@ class WMClientTest extends \PHPUnit_Framework_TestCase
         ])->willReturn($response);
         return $httpClient;
     }
-
-    public function testLookupHeaderMixedCase()
-        {
-            $ua = "Mozilla/5.0 (Nintendo Switch; WebApplet) AppleWebKit/601.6 (KHTML, like Gecko) NF/4.0.0.5.9 NintendoBrowser/5.1.0.13341";
-            $default_ua = 'php-wmclient-api ' . 'WM-test';
-            $expected_request_ua = $default_ua . ' ' . $ua;
-            $httpClient = $this->prophesize('\ScientiaMobile\WMClient\HttpClient\HttpClientInterface');
-            $response = ResponseMocker::wmValidServerInfoResponse();
-            $httpClient->getDefaultUserAgent()->willReturn('WM-test');
-            $httpClient->get("/v2/getinfo/json", [
-                "User-Agent" => $default_ua,
-            ])->willReturn($response);
-            $httpClient->post(
-                "/v2/lookuprequest/json",
-                [
-                    "User-Agent" => $expected_request_ua,
-                    "Accept-Encoding" => "gzip, deflate",
-                    "X-UCBrowser-Device-UA" => "Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S5253/S5253DDJI7; U; Bada/1.0; en-us) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WQVGA SMM-MMS/1.2.0 OPN-B",
-                ],
-                Argument::any()
-            )
-                ->willReturn(ResponseMocker::wmValidDeviceResponse());
-
-            $client = new WMClient($httpClient->reveal());
-            $url = "http://vimeo.com/api/v2/brad/info.json";
-            $headers = [
-                "Content-Type" => "application/json",
-                "AccEpt-Encoding" => "gzip, deflate",
-                "X-uCBrowser-device-UA" => "Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S5253/S5253DDJI7; U; Bada/1.0; en-us) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WQVGA SMM-MMS/1.2.0 OPN-B",
-                "user-agent" => $ua,
-            ];
-            $request = new Request("GET", $url, $headers);
-
-            $client->lookupRequest($request);
-        }
 }


### PR DESCRIPTION
This PR makes wurfl microservice client PHP send only its internal user-agent as header in HTTP requests 
All headers used for device detection are only sent as JSON request payload.